### PR TITLE
Fix WhatsApp contact button

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -115,7 +115,12 @@
     const msg=buildWhatsAppMessage(); if(!msg) return;
     const url=`https://wa.me/${window.__WA_NUMBER__}?text=${msg}`; window.open(url,'_blank');
   }
-  window.openWhatsAppFromContact = openWhatsApp;
+
+  function openWhatsAppFromContact(){
+    const url=`https://wa.me/${window.__WA_NUMBER__}`;
+    window.open(url,'_blank');
+  }
+  window.openWhatsAppFromContact = openWhatsAppFromContact;
 
   function renderFeatured(){
     const featured=$('#featured'); if(!featured || !window.__PRODUCTS__) return;


### PR DESCRIPTION
## Summary
- add dedicated function for contact page so WhatsApp link opens even without cart items

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1147b1944832196b543423bef5f06